### PR TITLE
Add Memcached caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ This project is a Spring Boot application that demonstrates a simple booking man
 
 - **Java 21**
 - **Gradle** (the project includes the Gradle wrapper)
-- **Docker** and **docker-compose** for running PostgreSQL
+- **Docker** and **docker-compose** for running PostgreSQL and Memcached
 
 ## Getting Started
 
-1. **Start PostgreSQL using `docker-compose`**
+1. **Start PostgreSQL and Memcached using `docker-compose`**
 
    ```bash
    docker-compose up -d
    ```
 
-   This starts a PostgreSQL instance configured with database `booking_db`,
-   user `booking_user` and password `booking_pass`.
+   This starts both PostgreSQL and a Memcached instance configured with
+   database `booking_db`, user `booking_user` and password `booking_pass`.
 
 2. **Build the project**
 
@@ -38,6 +38,12 @@ This project is a Spring Boot application that demonstrates a simple booking man
    ```
 
 The service will start on `http://localhost:8080`.
+
+### Caching with Memcached
+
+The application checks Memcached before querying the database for user lists.
+The default configuration expects a Memcached server running on `localhost:11211`
+(automatically started via `docker-compose`).
 
 ## API Endpoints
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+        implementation 'net.spy:spymemcached:2.12.3'
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,5 +14,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  memcached:
+    image: memcached:1.6
+    container_name: booking_memcached
+    ports:
+      - "11211:11211"
+
 volumes:
   postgres_data:

--- a/src/main/java/bookingManagementSystem/example/bookingManagementSystem/config/MemcachedConfig.java
+++ b/src/main/java/bookingManagementSystem/example/bookingManagementSystem/config/MemcachedConfig.java
@@ -1,0 +1,24 @@
+package bookingManagementSystem.example.bookingManagementSystem.config;
+
+import net.spy.memcached.MemcachedClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+@Configuration
+public class MemcachedConfig {
+
+    @Value("${memcached.host:localhost}")
+    private String host;
+
+    @Value("${memcached.port:11211}")
+    private int port;
+
+    @Bean
+    public MemcachedClient memcachedClient() throws IOException {
+        return new MemcachedClient(new InetSocketAddress(host, port));
+    }
+}

--- a/src/main/java/bookingManagementSystem/example/bookingManagementSystem/service/UserService.java
+++ b/src/main/java/bookingManagementSystem/example/bookingManagementSystem/service/UserService.java
@@ -3,6 +3,7 @@ package bookingManagementSystem.example.bookingManagementSystem.service;
 import bookingManagementSystem.example.bookingManagementSystem.model.entity.User;
 import bookingManagementSystem.example.bookingManagementSystem.repository.UserRepository;
 import lombok.AllArgsConstructor;
+import net.spy.memcached.MemcachedClient;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,9 +12,18 @@ import java.util.List;
 @AllArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final MemcachedClient memcachedClient;
+
+    private static final String USERS_CACHE_KEY = "users";
 
     public List<User> getUsers(){
-        return userRepository.findAll();
+        List<User> cached = (List<User>) memcachedClient.get(USERS_CACHE_KEY);
+        if (cached != null){
+            return cached;
+        }
+        List<User> users = userRepository.findAll();
+        memcachedClient.set(USERS_CACHE_KEY, 300, users);
+        return users;
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.password=booking_pass
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+memcached.host=localhost
+memcached.port=11211

--- a/src/test/java/bookingManagementSystem/example/bookingManagementSystem/service/UserServiceCachingTest.java
+++ b/src/test/java/bookingManagementSystem/example/bookingManagementSystem/service/UserServiceCachingTest.java
@@ -1,0 +1,41 @@
+package bookingManagementSystem.example.bookingManagementSystem.service;
+
+import bookingManagementSystem.example.bookingManagementSystem.model.entity.User;
+import bookingManagementSystem.example.bookingManagementSystem.repository.UserRepository;
+import net.spy.memcached.MemcachedClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceCachingTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MemcachedClient memcachedClient;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void getUsersUsesCacheWhenAvailable() {
+        List<User> users = List.of(new User());
+        when(memcachedClient.get("users")).thenReturn(null).thenReturn(users);
+        when(userRepository.findAll()).thenReturn(users);
+
+        userService.getUsers();
+        verify(userRepository, times(1)).findAll();
+        verify(memcachedClient).set("users", 300, users);
+
+        userService.getUsers();
+        verifyNoMoreInteractions(userRepository);
+    }
+}


### PR DESCRIPTION
## Summary
- add `spymemcached` dependency
- set up memcached service in docker-compose
- configure `MemcachedClient` bean
- cache user list in `UserService`
- document memcached usage in README
- test that cached results avoid repository calls

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847b584d7a8832f99337e607c122b21